### PR TITLE
Update target id on export.js

### DIFF
--- a/src/js/modules/export.js
+++ b/src/js/modules/export.js
@@ -49,7 +49,7 @@ async function exportPNG() {
     Alert.show(`Compile a diagram to export`, 4000);
     return;
   }
-  const svgEl = document.getElementById("d2-svg");
+  const svgEl = document.getElementById("diagram");
 
   const viewBox = svgEl.getAttribute("viewBox").split(" ");
   const width = parseFloat(viewBox[2]) * window.devicePixelRatio;


### PR DESCRIPTION
This pull request includes a change to the `export.js` file to correct the element identifier used for exporting a diagram as a PNG.

* [`src/js/modules/export.js`](diffhunk://#diff-3c9ed07a5e6f3b971f0ff87be5c324df6f43a762858cf025c1dfcd36b2c4878cL52-R52): Changed the element ID from `"d2-svg"` to `"diagram"` in the `exportPNG` function to ensure the correct element is selected for export.Updated the target id

Related Issue: #70 