### PR TITLE
Update Playground links for d2lang

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/js/d2-vscode"]
 	path = src/js/d2-vscode
-	url = https://github.com/terrastruct/d2-vscode.git
+	url = https://github.com/d2lang/d2-vscode.git
 [submodule "ci/sub"]
 	path = ci/sub
 	url = https://github.com/terrastruct/ci.git

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
     An online runner to play, learn, and create with D2, the modern diagram scripting language that turns text to diagrams.
   </h2>
 
-[![ci](https://github.com/terrastruct/d2-playground/actions/workflows/ci.yml/badge.svg)](https://github.com/terrastruct/d2-playground/actions/workflows/ci.yml)
-[![daily](https://github.com/terrastruct/d2-playground/actions/workflows/daily.yml/badge.svg)](https://github.com/terrastruct/d2-playground/actions/workflows/daily.yml)
+[![ci](https://github.com/d2lang/d2-playground/actions/workflows/ci.yml/badge.svg)](https://github.com/d2lang/d2-playground/actions/workflows/ci.yml)
+[![daily](https://github.com/d2lang/d2-playground/actions/workflows/daily.yml/badge.svg)](https://github.com/d2lang/d2-playground/actions/workflows/daily.yml)
 [![discord](https://img.shields.io/discord/1039184639652265985?label=discord)](https://discord.gg/NF6X8K4eDq)
 [![twitter](https://img.shields.io/twitter/follow/terrastruct?style=social)](https://twitter.com/terrastruct)
-[![license](https://img.shields.io/github/license/terrastruct/d2-playground?color=9cf)](./LICENSE.txt)
+[![license](https://img.shields.io/github/license/d2lang/d2-playground?color=9cf)](./LICENSE.txt)
 
 </div>
 
-**Notice:** This is not the repository for the D2 language. That can be found [here](https://github.com/terrastruct/d2).
+**Notice:** This is not the repository for the D2 language. That can be found [here](https://github.com/d2lang/d2).
 
 # Table of Contents
 

--- a/src/index.html
+++ b/src/index.html
@@ -82,7 +82,7 @@
           >Icons</a
         >
         <a class="nav-menu-item" target="_blank" href="https://d2lang.com">Docs</a>
-        <a class="nav-menu-item" target="_blank" href="https://github.com/terrastruct/d2"
+        <a class="nav-menu-item" target="_blank" href="https://github.com/d2lang/d2"
           >Github</a
         >
         <button class="nav-menu-item" id="btn-toggle-theme">
@@ -104,7 +104,7 @@
           class="nav-menu-item"
           id="download-cli"
           target="_blank"
-          href="https://github.com/terrastruct/d2#install"
+          href="https://github.com/d2lang/d2#install"
         >
           <button class="btn btn-shiny">Download CLI</button>
         </a>
@@ -354,7 +354,7 @@
           <a href="https://discord.gg/NF6X8K4eDq">
             <img src="assets/icons/discord.svg" />
           </a>
-          <a href="https://github.com/terrastruct/d2">
+          <a href="https://github.com/d2lang/d2">
             <img src="assets/icons/github.svg" />
           </a>
         </div>

--- a/src/js/modules/editor.js
+++ b/src/js/modules/editor.js
@@ -269,7 +269,7 @@ async function compile() {
     if (!encoded) {
       const urlEncoded = encodeURIComponent(window.location.href);
       Alert.show(
-        `D2 encountered an encoding error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/terrastruct/d2/issues/new?body=${urlEncoded}">Github</a>.`,
+        `D2 encountered an encoding error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${urlEncoded}">Github</a>.`,
         6000
       );
       unlockCompileBtn();
@@ -279,7 +279,7 @@ async function compile() {
     console.error("D2 Compile: Encode failed", err);
     const urlEncoded = encodeURIComponent(window.location.href);
     Alert.show(
-      `D2 encountered an encoding error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/terrastruct/d2/issues/new?body=${urlEncoded}">Github</a>.`,
+      `D2 encountered an encoding error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${urlEncoded}">Github</a>.`,
       6000
     );
     unlockCompileBtn();
@@ -333,7 +333,7 @@ async function compile() {
     if (response.status === 500) {
       const urlEncoded = encodeURIComponent(window.location.href);
       Alert.show(
-        `D2 encountered an API error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/terrastruct/d2/issues/new?body=${urlEncoded}">Github</a>.`,
+        `D2 encountered an API error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${urlEncoded}">Github</a>.`,
         6000
       );
       return;
@@ -348,7 +348,7 @@ async function compile() {
     if (!response.ok) {
       const urlEncoded = encodeURIComponent(window.location.href);
       Alert.show(
-        `D2 encountered an unexpected error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/terrastruct/d2/issues/new?body=${urlEncoded}">Github</a>.`,
+        `D2 encountered an unexpected error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${urlEncoded}">Github</a>.`,
         6000
       );
       return;
@@ -395,7 +395,7 @@ async function compile() {
       hideLoader();
       unlockCompileBtn();
       Alert.show(
-        `D2 encountered a compile error: "${err.message}". Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/terrastruct/d2/issues/new?body=${urlEncoded}">Github</a>.`,
+        `D2 encountered a compile error: "${err.message}". Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${urlEncoded}">Github</a>.`,
         6000
       );
       return;
@@ -413,7 +413,7 @@ async function compile() {
       console.error("failed to render", renderErr);
       const urlEncoded = encodeURIComponent(window.location.href);
       Alert.show(
-        `D2 encountered an unexpected error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/terrastruct/d2/issues/new?body=${urlEncoded}">Github</a>.`,
+        `D2 encountered an unexpected error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${urlEncoded}">Github</a>.`,
         6000
       );
     }

--- a/src/js/modules/export.js
+++ b/src/js/modules/export.js
@@ -168,7 +168,7 @@ async function exportPNG() {
     img = await loadImage();
   } catch (e) {
     Alert.show(
-      `Converting to PNG failed: ${e}. Please help improve D2 by sharing this link on&nbsp;<a href="https://github.com/terrastruct/d2/issues/new?body=${encodeURIComponent(
+      `Converting to PNG failed: ${e}. Please help improve D2 by sharing this link on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${encodeURIComponent(
         window.location.href
       )}">Github</a>.`,
       4000
@@ -252,7 +252,7 @@ async function exportPNGClipboard() {
     img = await loadImage();
   } catch (e) {
     Alert.show(
-      `Converting to PNG failed: ${e}. Please help improve D2 by sharing this link on&nbsp;<a href="https://github.com/terrastruct/d2/issues/new?body=${encodeURIComponent(
+      `Converting to PNG failed: ${e}. Please help improve D2 by sharing this link on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${encodeURIComponent(
         window.location.href
       )}">Github</a>.`,
       4000

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -2,7 +2,7 @@
   "name": "d2-playground",
   "version": "1.0.0",
   "description": "An online runner to play, learn, and create with D2, the modern diagram scripting language that turns text to diagrams.",
-  "repository": "https://github.com/terrastruct/d2-playground",
+  "repository": "https://github.com/d2lang/d2-playground",
   "author": "Terrastruct, Inc.",
   "license": "MPL 2.0",
   "dependencies": {


### PR DESCRIPTION
## What changed

- Update Playground badges, repository metadata, navigation, CLI download, footer, and error-report links to d2lang.
- Update the d2-vscode submodule URL while retaining terrastruct/ci.

## Validation

- JavaScript syntax checks passed for the changed modules.
- package.json parses successfully.
- git diff --check passed.