### PR TITLE
Deploy playground through AWS OIDC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,11 +9,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PLAYGROUND_S3_BUCKET: s3://d2lang-playground-278852893615
+  PLAYGROUND_CLOUDFRONT_ID: E1RNQAJ339Z6K4
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: production
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -25,8 +32,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::278852893615:role/d2lang-playground-deploy
           aws-region: us-west-1
       - name: Install dependencies
         run: |
@@ -39,6 +45,3 @@ jobs:
           yarn install
       - name: Deploy to production
         run: ./ci/deploy.sh
-        env:
-          PLAYGROUND_CLOUDFRONT_ID: ${{ secrets.PLAYGROUND_CLOUDFRONT_ID }}
-          PLAYGROUND_S3_BUCKET: ${{ secrets.PLAYGROUND_S3_BUCKET }}


### PR DESCRIPTION
## What changed

- grant the production deploy job `contents: read` and `id-token: write`
- assume the new `d2lang-playground-deploy` AWS role through GitHub OIDC
- point deploys at the D2-owned S3 bucket and CloudFront distribution with committed, non-secret workflow environment values
- remove the static AWS key and deploy-target secret inputs

## Why

Playground deployments need to target the new D2-owned AWS infrastructure without retaining long-lived AWS credentials in GitHub.

## Impact

This only changes deployment authentication and destination configuration. It does not change TALA or other playground source code, merge the change, or alter DNS.

## Validation

- parsed `.github/workflows/deploy.yml` successfully as YAML
- `git diff --check`
- confirmed the diff contains only `.github/workflows/deploy.yml`
- confirmed static AWS credential inputs and secret-backed deploy target references are absent
