### PR TITLE
Remove the playground API dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,8 @@ Vanilla HTML, CSS, and Javascript.
 
 ### How does it work?
 
-[d2.js](https://www.npmjs.com/package/@terrastruct/d2) serves every request for dagre and
-elk layouts all within the frontend client. To render
-[tala](https://d2lang.com/tour/tala/) layouts, a request is made to an API (since it's not
-supported by `d2.js`).
+[d2.js](https://www.npmjs.com/package/@terrastruct/d2) compiles and renders both Dagre and
+ELK layouts entirely within the browser.
 
 ### Can I run it locally?
 

--- a/src/css/workstation.css
+++ b/src/css/workstation.css
@@ -140,29 +140,6 @@
   color: var(--steel-800);
 }
 
-#key {
-  width: 20px;
-}
-
-#key-explanation {
-  width: 100%;
-}
-
-#key-explanation > a {
-  color: var(--blue-500);
-}
-
-#key-input {
-  width: calc(100% - 0.8rem);
-  resize: none;
-  height: 3rem;
-  margin-top: 1rem;
-  padding: 0.4rem;
-  background-color: var(--steel-050);
-  color: var(--steel-850);
-  border: 1px solid var(--blue-200);
-}
-
 #mobile-editor {
   font-family: "Source Code Pro";
   font-size: 16px;

--- a/src/index.html
+++ b/src/index.html
@@ -182,12 +182,6 @@
                 <div id="editor-toolbar-left-label">Live editor</div>
               </div>
               <div id="editor-toolbar-right" class="workstation-toolbar-right">
-                <img
-                  src="assets/icons/key.svg"
-                  id="key"
-                  class="clickable-icon"
-                  style="display: none"
-                />
                 <div class="btn-menu-container">
                   <button id="layout-btn" class="btn btn-labeled">
                     <div class="btn-label">Layout engine</div>
@@ -197,7 +191,6 @@
                   <div id="layout-menu" class="btn-menu" style="display: none">
                     <div class="btn-menu-item layout-menu-item">Dagre</div>
                     <div class="btn-menu-item layout-menu-item">ELK</div>
-                    <div class="btn-menu-item layout-menu-item">TALA</div>
                   </div>
                 </div>
                 <button id="compile-btn" class="btn btn-primary btn-disabled">

--- a/src/js/modules/editor.js
+++ b/src/js/modules/editor.js
@@ -297,129 +297,70 @@ async function compile() {
   clearCompileErrors();
   showLoader();
 
-  // TALA uses remote rendering
-  if (layout === "tala") {
-    const talaKey = Layout.getTALAKey();
-
-    const headers = {};
-    if (layout == "tala" && talaKey) {
-      headers["x-tala-key"] = talaKey;
-    }
-    let response;
-    try {
-      let apiUrl = `https://api.d2lang.com/render/svg?script=${encoded}&layout=${layout}&theme=${Theme.getThemeID()}`;
-      if (ascii) {
-        apiUrl += `&ascii=1`;
-      }
-      if (sketch) {
-        apiUrl += `&sketch=1`;
-      }
-      response = await fetch(apiUrl, {
-        headers,
-        method: "GET",
-      });
-    } catch (e) {
-      // 4-500s do not throw
-      Alert.show(
-        `Unexpected error occurred. Please make sure you are connected to the internet.`,
-        6000
-      );
-      hideLoader();
-      unlockCompileBtn();
-      return;
-    }
-    hideLoader();
-    unlockCompileBtn();
-    if (response.status === 500) {
-      const urlEncoded = encodeURIComponent(window.location.href);
-      Alert.show(
-        `D2 encountered an API error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${urlEncoded}">Github</a>.`,
-        6000
-      );
-      return;
-    }
-    if (response.status === 403) {
-      Alert.show(
-        `You're doing that a bit too much. Please reach out to us at hi@d2lang.com if you're a human.`,
-        6000
-      );
-      return;
-    }
-    if (!response.ok) {
-      const urlEncoded = encodeURIComponent(window.location.href);
-      Alert.show(
-        `D2 encountered an unexpected error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${urlEncoded}">Github</a>.`,
-        6000
-      );
-      return;
-    }
-    svg = await response.text();
-  } else {
-    const compileRequest = {
-      fs: { index: script },
-      options: {
-        layout,
-        sketch: ascii ? false : sketch,
-        ascii,
-        forceAppendix: false,
-        target: "",
-        animateInterval: 0,
-        salt: "",
-        noXMLTag: false,
-      },
-    };
-
-    let compiled;
-    try {
-      compiled = await window.d2.compile(compileRequest);
-      if (compiled.fs && compiled.fs.index) {
-        script = compiled.fs.index;
-        setScript(script);
-      }
-    } catch (err) {
-      // Check if this is a parse error (JSON array of error objects)
-      if (err.message && err.message.startsWith("[")) {
-        try {
-          const errorData = JSON.parse(err.message);
-          if (Array.isArray(errorData) && errorData.length > 0 && errorData[0].errmsg) {
-            displayCompileErrors(errorData);
-            hideLoader();
-            unlockCompileBtn();
-            return;
-          }
-        } catch (parseErr) {
-          // fallthrough to generic error handling
-        }
-      }
-      const urlEncoded = encodeURIComponent(window.location.href);
-      hideLoader();
-      unlockCompileBtn();
-      Alert.show(
-        `D2 encountered a compile error: "${err.message}". Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${urlEncoded}">Github</a>.`,
-        6000
-      );
-      return;
-    }
-    const renderOptions = {
-      layout: layout,
+  const compileRequest = {
+    fs: { index: script },
+    options: {
+      layout,
       sketch: ascii ? false : sketch,
       ascii,
-      themeID: Theme.getThemeID(),
-      center: true,
-    };
-    try {
-      svg = await window.d2.render(compiled.diagram, renderOptions);
-    } catch (renderErr) {
-      console.error("failed to render", renderErr);
-      const urlEncoded = encodeURIComponent(window.location.href);
-      Alert.show(
-        `D2 encountered an unexpected error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${urlEncoded}">Github</a>.`,
-        6000
-      );
+      forceAppendix: false,
+      target: "",
+      animateInterval: 0,
+      salt: "",
+      noXMLTag: false,
+    },
+  };
+
+  let compiled;
+  try {
+    compiled = await window.d2.compile(compileRequest);
+    if (compiled.fs && compiled.fs.index) {
+      script = compiled.fs.index;
+      setScript(script);
     }
+  } catch (err) {
+    // Check if this is a parse error (JSON array of error objects)
+    if (err.message && err.message.startsWith("[")) {
+      try {
+        const errorData = JSON.parse(err.message);
+        if (Array.isArray(errorData) && errorData.length > 0 && errorData[0].errmsg) {
+          displayCompileErrors(errorData);
+          hideLoader();
+          unlockCompileBtn();
+          return;
+        }
+      } catch (parseErr) {
+        // fallthrough to generic error handling
+      }
+    }
+    const urlEncoded = encodeURIComponent(window.location.href);
     hideLoader();
     unlockCompileBtn();
+    Alert.show(
+      `D2 encountered a compile error: "${err.message}". Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${urlEncoded}">Github</a>.`,
+      6000
+    );
+    return;
   }
+  const renderOptions = {
+    layout: layout,
+    sketch: ascii ? false : sketch,
+    ascii,
+    themeID: Theme.getThemeID(),
+    center: true,
+  };
+  try {
+    svg = await window.d2.render(compiled.diagram, renderOptions);
+  } catch (renderErr) {
+    console.error("failed to render", renderErr);
+    const urlEncoded = encodeURIComponent(window.location.href);
+    Alert.show(
+      `D2 encountered an unexpected error. Please help improve D2 by opening an issue on&nbsp;<a href="https://github.com/d2lang/d2/issues/new?body=${urlEncoded}">Github</a>.`,
+      6000
+    );
+  }
+  hideLoader();
+  unlockCompileBtn();
 
   const renderEl = document.getElementById("render-svg");
   const containerWidth = renderEl.getBoundingClientRect().width;

--- a/src/js/modules/layout.js
+++ b/src/js/modules/layout.js
@@ -1,47 +1,18 @@
-import Modal from "./modal";
-import Alert from "./alert";
 import Editor from "./editor.js";
 
 import QueryParams from "../lib/queryparams";
-import LocalStorage from "../lib/localstorage";
 
-let talaKey;
 let layout = "dagre";
 
 function init() {
   document.getElementById("layout-btn").addEventListener("click", toggleMenu);
   document.getElementById("layout-menu").addEventListener("mouseleave", hideMenu);
-  document.getElementById("key").addEventListener("click", inputTALAKey);
 
   for (const el of document.getElementsByClassName("layout-menu-item")) {
     el.addEventListener("click", changeLayout);
   }
 
-  const storedKey = LocalStorage.get("talaKey");
-  if (storedKey) {
-    talaKey = storedKey;
-  }
   readQueryParam();
-}
-
-function inputTALAKey() {
-  let content = `<div id="key-explanation">
-    TALA is a proprietary layout engine. It is free to evaluate, but requires a valid license key to remove the watermark. You can find more information about TALA and license keys <a href="https://terrastruct.com/tala/">here</a>.
-  </div>
-  <textarea id="key-input" placeholder="tstruct_XXX">${talaKey || ""}</textarea>`;
-
-  Modal.show("TALA License Key", content, "Attach to browser requests", attachKey);
-}
-
-function attachKey() {
-  const input = document.getElementById("key-input").value;
-  if (!input.startsWith("tstruct_")) {
-    Alert.show("License key does not look valid.", 4000);
-    return;
-  }
-  talaKey = input;
-  LocalStorage.set("talaKey", talaKey);
-  Modal.close();
 }
 
 function readQueryParam() {
@@ -56,7 +27,6 @@ function readQueryParam() {
       valid = true;
       document.getElementById("current-layout").textContent = el.textContent;
       layout = el.textContent.toLowerCase();
-      setKeyVisibility();
     }
   }
 
@@ -69,7 +39,6 @@ function changeLayout(e) {
   layout = e.target.textContent.toLowerCase();
   document.getElementById("current-layout").textContent = e.target.textContent;
   QueryParams.set("layout", layout);
-  setKeyVisibility();
   hideMenu();
   if (Editor.getDiagramSVG()) {
     Editor.compile();
@@ -93,20 +62,7 @@ function getLayout() {
   return layout;
 }
 
-function setKeyVisibility() {
-  if (layout === "tala") {
-    document.getElementById("key").style.display = "block";
-  } else {
-    document.getElementById("key").style.display = "none";
-  }
-}
-
-function getTALAKey() {
-  return talaKey;
-}
-
 export default {
   init,
   getLayout,
-  getTALAKey,
 };


### PR DESCRIPTION
The ordinary D2 playground already compiles and renders Dagre and ELK entirely in the browser. Remove the remaining TALA-only UI, license-key storage, and `api.d2lang.com/render/svg` request path so the playground no longer depends on the Terrastruct-hosted renderer.

Existing `?layout=tala` links now follow the existing invalid-layout behavior: the parameter is removed and Dagre remains selected.

Validation:
- Prettier 2.8.1 on changed HTML, CSS, and JavaScript
- `node --check` on both changed JavaScript modules
- production-style esbuild bundle completed successfully
- built bundle contains no `api.d2lang.com`, `/render/svg`, TALA key header, or TALA key UI strings
- `git diff --check`

The full local `./make.sh` could not complete on this machine because Go and Pandoc are unavailable; GitHub CI is the authoritative full test.

Codex (OpenAI) assisted with the dependency removal and PR preparation; the resulting source diff and bundle were reviewed before requesting review.