### PR TITLE
Update transferred dependency links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/d2lang/d2-vscode.git
 [submodule "ci/sub"]
 	path = ci/sub
-	url = https://github.com/terrastruct/ci.git
+	url = https://github.com/d2lang/ci.git


### PR DESCRIPTION
## What changed

- update canonical links from `terrastruct/ci` and `terrastruct/util-go` to their new `d2lang` repository locations
- keep the existing Go vanity module path unchanged

## Why

The dependency repositories have moved to the `d2lang` organization. New clones and contributors should use the canonical locations rather than GitHub compatibility redirects.

## Checks

- `git diff --check`
- transferred repository IDs and old-location redirects verified
