### PR TITLE
Use GitHub Actions token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ci
 on: [push, pull_request]
+permissions:
+  actions: read
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -15,7 +18,7 @@ jobs:
           cache: true
       - run: COLOR=1 ./make.sh
         env:
-          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
   nofixups:
     runs-on: ubuntu-latest
@@ -24,5 +27,5 @@ jobs:
       - run: git submodule update --init
       - run: COLOR=1 ./ci/sub/bin/nofixups.sh
         env:
-          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '42 0 * * *' # daily at 00:42
+permissions:
+  actions: read
+  contents: read
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -18,5 +21,5 @@ jobs:
           cache: true
       - run: COLOR=1 CI_FORCE=1 ./make.sh
         env:
-          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

- replace the long-lived `_GITHUB_TOKEN` repository secret with the per-run `github.token`
- explicitly grant workflows `actions: read` and `contents: read`
- leave Slack/Discord webhook credentials unchanged

The old repository secret should be deleted only after this runs successfully on the protected default branch.

## Validation

- YAML parse
- actionlint (excluding existing old-action-version warnings)
- `git diff --check`
- confirmed no `_GITHUB_TOKEN` references remain in the workflows