### PR TITLE
deploy: keep Monaco WASM raw

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -74,15 +74,9 @@ main() {
   runjob 'aws s3 sync brotli' "aws s3 cp ./dist/build/out.js ${PLAYGROUND_S3_BUCKET}/build/out.js --content-encoding='br' --content-type='application/javascript' --metadata-directive='REPLACE' --no-progress"
   runjob 'aws s3 sync brotli css' "aws s3 cp ./dist/build/style.css ${PLAYGROUND_S3_BUCKET}/build/style.css --content-encoding='br' --content-type='text/css' --metadata-directive='REPLACE' --no-progress"
 
+  # Keep WASM assets raw in dist so the build remains safe to sync or mirror.
+  # Precompressed objects require matching Content-Encoding metadata.
   runjob 'aws s3 sync' "aws s3 sync ./dist ${PLAYGROUND_S3_BUCKET} --delete --no-progress --exclude='build/out.js' --exclude='build/style.css'"
-
-  # TODO should run the compression concurrent alongside build and deploy above
-  # Cloudfront does not support wasm compression, so we upload it compressed
-  bigheader "Monaco WASM"
-
-  # TODO only run wasm if differs from dist. slow.
-
-  brotli -c src/js/vendor/onig.wasm > dist/js/vendor/onig.wasm
 
   bigheader "Invalidating cache"
 


### PR DESCRIPTION
## What changed

- remove the post-deploy Brotli rewrite of `dist/js/vendor/onig.wasm`
- keep WASM assets raw throughout the deploy and any subsequent mirror
- retain the existing explicitly encoded JS and CSS uploads

## Why

The deploy script synced `dist` first and then replaced `dist/js/vendor/onig.wasm` with Brotli bytes without uploading it or attaching `Content-Encoding` metadata. Reusing that mutated directory for the source-account mirror stored compressed bytes as an ordinary WASM object. The live CloudFront distribution compressed it again, and browsers received Brotli bytes instead of the WebAssembly magic header, preventing Monaco from initializing.

Keeping WASM raw makes the build directory safe to re-sync and mirror. Any future precompression must use matching object metadata.

## Impact

Future playground deploys and mirrors will publish a directly usable `onig.wasm` instead of leaving a hazardous post-deploy artifact. This does not change the explicit Brotli handling for the large JavaScript and CSS bundles.

## Validation

- `bash -n ci/deploy.sh`
- `git diff --check`

No new test was added.
