### PR TITLE
deps: migrate d2.js to d2lang npm scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Vanilla HTML, CSS, and Javascript.
 
 ### How does it work?
 
-[d2.js](https://www.npmjs.com/package/@terrastruct/d2) compiles and renders both Dagre and
+[d2.js](https://www.npmjs.com/package/@d2lang/d2) compiles and renders both Dagre and
 ELK layouts entirely within the browser.
 
 ### Can I run it locally?

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,6 +1,6 @@
 import Editor from "./modules/editor.js";
-import { D2 } from "@terrastruct/d2";
-import d2jsPackage from "../js/node_modules/@terrastruct/d2/package.json";
+import { D2 } from "@d2lang/d2";
+import d2jsPackage from "../js/node_modules/@d2lang/d2/package.json";
 
 import WebTheme from "./modules/web_theme.js";
 import Export from "./modules/export.js";

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -6,7 +6,7 @@
   "author": "Terrastruct, Inc.",
   "license": "MPL 2.0",
   "dependencies": {
-    "@terrastruct/d2": "^0.1.33",
+    "@d2lang/d2": "^0.1.33",
     "monaco-editor": "^0.34.1",
     "shiki": "^0.11.1",
     "vscode-oniguruma": "^1.7.0",

--- a/src/js/yarn.lock
+++ b/src/js/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@terrastruct/d2@^0.1.33":
+"@d2lang/d2@^0.1.33":
   version "0.1.33"
-  resolved "https://registry.yarnpkg.com/@terrastruct/d2/-/d2-0.1.33.tgz#8e9bde66c3316f3e18ffb576bdeab5c667f328a3"
-  integrity sha512-eK5hyfGIJFolC7sUsiKvWdY9xGFctTe3d+PSijo09IYDso8psztC+A4SammizXtlwYZpnnW0AtDjfBYauceSeA==
+  resolved "https://registry.yarnpkg.com/@d2lang/d2/-/d2-0.1.33.tgz#95dabe1f1963ddec8108a7f7ed45808d4c53c4fc"
+  integrity sha512-amVNjWeVHffM2PIZLEiTXiweoqMBtnw85+DuP5htqTRF70nz1PaEq76lkGQB6gLiUqGd8rdSBjobR7TteiZuJA==
 
 jsonc-parser@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
## Summary

- switch the playground dependency and imports from `@terrastruct/d2` to canonical `@d2lang/d2`
- update the frozen Yarn 1 lock entry to the verified public `0.1.33` tarball
- point the README package link at the new namespace

## Validation

- Yarn 1.22.22 frozen-lockfile install
- production JS/CSS builds with current and project-pinned esbuild
- real D2 compile/render smoke test
- `go test ./...`
- `go build ./...`
- `go vet --composites=false ./...`
- Prettier and `git diff --check`
