### PR TITLE
use GitHub module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module oss.terrastruct.com/d2-playground
+module github.com/d2lang/d2-playground
 
 go 1.19
 


### PR DESCRIPTION
## What changed\n\n- Change the active Go module identity from oss.terrastruct.com/d2-playground to github.com/d2lang/d2-playground.\n\n## Why\n\nThe repository now lives in the d2lang organization and has no known consumers of the old vanity module path. Using the GitHub path removes the active Playground build dependency on Terrastruct DNS.\n\nThe previously published old-path pseudo-version remains immutable in the Go proxy.\n\n## Validation\n\n- go list ./...\n- COLOR=1 ./make.sh\n- git diff --check\n\nAfter merge, successful default-branch CI will trigger the production deploy; that deploy will also serve as the post-cutover Playground deployment proof.